### PR TITLE
Minor fixes for Mailable.

### DIFF
--- a/src/Loggers/MailLogger.php
+++ b/src/Loggers/MailLogger.php
@@ -36,7 +36,7 @@ class MailLogger
         return $this;
     }
 
-    protected function sendMailToRay(PHPMailer $mailer)
+    public function sendMailToRay(PHPMailer $mailer)
     {
         $mailable = new Mailable($mailer);
 

--- a/src/Payloads/MailPayload.php
+++ b/src/Payloads/MailPayload.php
@@ -22,7 +22,7 @@ class MailPayload extends Payload
     public function getContent(): array
     {
         $content = [
-            'html' => $this->html,
+            'html' => '',
             'from' => [],
             'to' => [],
             'cc' => [],


### PR DESCRIPTION
Fixing a warning and notice:

```
PHP Warning:  call_user_func_array() expects parameter 1 to be a valid callback, cannot access protected method Spatie\WordpressRay\Loggers\MailLogger::sendMailToRay()
```

And

```
PHP Notice:  Undefined property: Spatie\WordpressRay\Payloads\MailPayload::$html in /wp-content/plugins/wordpress-ray/src/Payloads/MailPayload.php on line 25
```