### PR TITLE
Adds HookLogger

### DIFF
--- a/src/Loggers/HookLogger.php
+++ b/src/Loggers/HookLogger.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\WordPressRay\Loggers;
+
+use Spatie\WordPressRay\Payloads\HookPayload;
+
+class HookLogger
+{
+    protected bool $active = false;
+
+    public function showHooks(): self
+    {
+        if ($this->active) {
+            return $this;
+        }
+
+        add_action('all', [$this, 'sendHookToRay'], 1, 20);
+
+        $this->active = true;
+
+        return $this;
+    }
+
+    public function stopShowingHooks(): self
+    {
+        if (! $this->active) {
+            return $this;
+        }
+
+        remove_action('all', [$this, 'sendHookToRay'], 1, 20);
+
+        $this->active = false;
+
+        return $this;
+    }
+
+    public function sendHookToRay($name, ...$arguments): void
+    {
+        $payload = new HookPayload($name, $arguments);
+
+        ray()->sendRequest($payload);
+    }
+}

--- a/src/OriginFactory.php
+++ b/src/OriginFactory.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\WordPressRay;
 
+use Spatie\WordPressRay\Loggers\HookLogger;
 use Spatie\WordPressRay\Loggers\MailLogger;
 use Spatie\WordPressRay\Loggers\QueryLogger;
 use Spatie\WordPressRay\Spatie\Backtrace\Frame;
@@ -28,6 +29,10 @@ class OriginFactory extends DefaultOriginFactory
 
         if ($rayFrame->class === MailLogger::class) {
             return $frames[$indexOfRay + 5];
+        }
+
+        if ($rayFrame->class === HookLogger::class) {
+            return $frames[$indexOfRay + 4];
         }
 
         return $rayFrame;

--- a/src/Payloads/HookPayload.php
+++ b/src/Payloads/HookPayload.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\WordPressRay\Payloads;
+
+use Spatie\WordPressRay\Spatie\Ray\ArgumentConverter;
+use Spatie\WordPressRay\Spatie\Ray\Payloads\Payload;
+
+class HookPayload extends Payload
+{
+    protected string $hookName;
+    protected array $payload = [];
+
+    public function __construct(string $hookName, array $payload)
+    {
+        $this->hookName = $hookName;
+        $this->payload = $payload;
+    }
+
+    public function getType(): string
+    {
+        return 'event';
+    }
+
+    public function getContent(): array
+    {
+        return [
+            'name' => $this->hookName,
+            'payload' => ArgumentConverter::convertToPrimitive($this->payload),
+        ];
+    }
+}

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\WordPressRay;
 
+use Spatie\WordPressRay\Loggers\HookLogger;
 use Spatie\WordPressRay\Loggers\MailLogger;
 use Spatie\WordPressRay\Loggers\QueryLogger;
 use Spatie\WordPressRay\Spatie\Ray\Payloads\Payload;
@@ -13,11 +14,15 @@ class Ray extends BaseRay
 
     protected static MailLogger $mailLogger;
 
+    protected static HookLogger $hookLogger;
+
     public static function bootForWordPress()
     {
         static::$queryLogger = new QueryLogger();
 
         static::$mailLogger = new MailLogger();
+
+        static::$hookLogger = new HookLogger();
 
         Payload::$originFactoryClass = OriginFactory::class;
     }
@@ -51,6 +56,20 @@ class Ray extends BaseRay
     public function stopShowingQueries(): self
     {
         static::$queryLogger->stopShowingQueries();
+
+        return $this;
+    }
+
+    public function showHooks(): self
+    {
+        static::$hookLogger->showHooks();
+
+        return $this;
+    }
+
+    public function stopShowingHooks(): self
+    {
+        static::$hookLogger->stopShowingHooks();
 
         return $this;
     }


### PR DESCRIPTION
This is the first pass for the `HookLogger`.

I used an `event` type payload. Hooks and events aren't the same but this works just fine.

**Sample code:**
```php
add_action( 'init', function() {
    ray()->showHooks();

    get_option( 'home' );

    ray()->stopShowingHooks();
} );
```

**Ray output:**
<img width="700" alt="Screenshot-3kr6c" src="https://user-images.githubusercontent.com/240569/104296963-b9ff0100-54db-11eb-9f45-f516221ed219.png">

Is it possible to change the label for the event type payload?