### PR TITLE
Update tested up to header and typo fix.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -54,7 +54,7 @@ This plugin adds no UI to WordPress. Here how the Ray desktop app looks like.
 
 == Frequently Asked Questions ==
 
-Want to know how to get started? Hear over to [our extensive docs](https://spatie.be/docs/ray).
+Want to know how to get started? Head over to [our extensive docs](https://spatie.be/docs/ray).
 
 
 Want to report a bug? Create an issue at [the spatie/wordpress-ray repo](https://github.com/spatie/wordpress-ray).

--- a/wp-ray.php
+++ b/wp-ray.php
@@ -9,7 +9,7 @@
  * Author URI: https://spatie.be
  * License: MIT
  * Requires PHP: 7.4
- * Tested up to: 5.5
+ * Tested up to: 5.6
  */
 
 use Spatie\WordPressRay\Ray;


### PR DESCRIPTION
I have used WordPress Ray on WordPress 5.6 (latest version), and it works without issue.

Also a minor typo fix in the readme.