### PR TITLE
Fix file path and add correct file path for ErrorLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `wordpress-ray` will be documented in this file.
 
+## Unreleased
+
+- fix origin file path
+- add correct origin file path for `showWordPressErrors`
+
 ## 1.3.2 - 2021-05-25
 
 - fix compatibility issues

--- a/src/OriginFactory.php
+++ b/src/OriginFactory.php
@@ -4,6 +4,7 @@ namespace Spatie\WordPressRay;
 
 use Spatie\WordPressRay\Loggers\HookLogger;
 use Spatie\WordPressRay\Loggers\MailLogger;
+use Spatie\WordPressRay\Loggers\ErrorLogger;
 use Spatie\WordPressRay\Loggers\QueryLogger;
 use Spatie\WordPressRay\Spatie\Backtrace\Frame;
 use Spatie\WordPressRay\Spatie\Ray\Origin\DefaultOriginFactory;
@@ -38,6 +39,10 @@ class OriginFactory extends DefaultOriginFactory
 
         if ($searchFrame && $searchFrame->class === HookLogger::class) {
             return $frames[$indexOfRay + 5];
+        }
+
+        if ($searchFrame && $searchFrame->class === ErrorLogger::class) {
+            return $frames[$indexOfRay + 6];
         }
 
         if (strpos($rayFrame->file, 'ray/vendor/autoload.php') !== false && $rayFrame->method === 'ray') {

--- a/src/OriginFactory.php
+++ b/src/OriginFactory.php
@@ -40,6 +40,10 @@ class OriginFactory extends DefaultOriginFactory
             return $frames[$indexOfRay + 5];
         }
 
+        if (strpos($rayFrame->file, 'ray/vendor/autoload.php') !== false && $rayFrame->method === 'ray') {
+            return $frames[$indexOfRay + 1];
+        }
+
         return $rayFrame;
     }
 }


### PR DESCRIPTION
This PR does two things:

* Fixes the origin file path. It was pointing to the `ray` alias created by PHP Scoper.
* Adds the correct origin file path for the ErrorLogger.

First original, second with fix:
<img width="634" alt="Screenshot 2021-05-27 at 23 46 57" src="https://user-images.githubusercontent.com/9550079/119902303-57b51300-bf47-11eb-8bdd-315b963454af.png">

First original, second with tweak:
<img width="634" alt="Screenshot 2021-05-27 at 23 51 41" src="https://user-images.githubusercontent.com/9550079/119902248-43711600-bf47-11eb-8495-78f1bda9454d.png">

