### PR TITLE
Increase the WordPress version the plugin was tested with

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://github.com/sponsors/spatie
 Tags: development, debugging
 Requires PHP: 7.3
 Requires at least: 5.5
-Tested up to: 5.6
+Tested up to: 5.8
 Stable tag: 1.5.0
 License: MIT
 


### PR DESCRIPTION
The current WordPress version is 5.8.x.
https://wordpress.org/download/

After the `readme.txt` file update in the repo just reupload everything to wordpress.org, without bumping the plugin version. This will fix "this plugin hasn't been tested with the current version of WordPress" notice that right now everyone sees when trying to install Ray plugin.