### PR TITLE
Fix namespaces for Spatie\Ray classes

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -6,8 +6,8 @@ use Spatie\WordPressRay\Loggers\ErrorLogger;
 use Spatie\WordPressRay\Loggers\HookLogger;
 use Spatie\WordPressRay\Loggers\MailLogger;
 use Spatie\WordPressRay\Loggers\QueryLogger;
-use Spatie\WordPressRay\Spatie\Ray\Payloads\Payload;
-use Spatie\WordPressRay\Spatie\Ray\Ray as BaseRay;
+use Spatie\Ray\Payloads\Payload;
+use Spatie\Ray\Ray as BaseRay;
 
 class Ray extends BaseRay
 {


### PR DESCRIPTION
Fix fatal error: Uncaught Error: Class 'Spatie\WordPressRay\Spatie\Ray\Ray' not found