### PR TITLE
Bump version and update gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,14 +2,23 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
-/.editorconfig      export-ignore
-/.gitattributes     export-ignore
-/.github            export-ignore
-/.gitignore         export-ignore
-/.php_cs.dist       export-ignore
-/composer.lock      export-ignore
-/phpunit.xml.dist   export-ignore
-/psalm.xml          export-ignore
-/tests              export-ignore
-/scoper.inc.php     export-ignore
-/build.sh           export-ignore
+/.editorconfig           export-ignore
+/.gitattributes         export-ignore
+/.github                export-ignore
+/.php_cs.dist           export-ignore
+/composer.lock          export-ignore
+/phpunit.xml.dist       export-ignore
+/psalm.xml              export-ignore
+/tests                  export-ignore
+/scoper.inc.php         export-ignore
+/build.sh               export-ignore
+/.idea                  export-ignore
+/.php_cs                export-ignore
+/.php_cs.cache          export-ignore
+/.phpunit.result.cache  export-ignore
+/build                  export-ignore
+/coverage               export-ignore
+/docs                   export-ignore
+/phpunit.xml            export-ignore
+/psalm.xml              export-ignore
+/vendor-bin             export-ignore

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: development, debugging, debug, developer
 Requires PHP: 8.0
 Requires at least: 5.5
 Tested up to: 6.1
-Stable tag: 1.5.6
+Stable tag: 1.7.0
 License: MIT
 
 Easily debug WordPress sites using Ray.

--- a/wp-ray.php
+++ b/wp-ray.php
@@ -4,7 +4,7 @@
  * Plugin Name: Spatie Ray
  * Plugin URI: https://github.com/spatie/wordpress-ray
  * Description: Easily debug WordPress apps
- * Version: 1.5.6
+ * Version: 1.7.0
  * Author: Spatie
  * Author URI: https://spatie.be
  * License: MIT


### PR DESCRIPTION
With the latest release on GitHub, the version wasn't updated to 1.7.0 within the plugin files. This PR adds that.

I also noticed that the vendor folder was not uploaded to WordPress SVN. I think due to it being in gitattributes ([See](https://github.com/spatie/wordpress-ray/actions/runs/3800218377/jobs/6463484400#step:4:486)). 

Hopefully you can undo the last release on GitHub and re-release after this PR is merged.