### PR TITLE
add distignore file

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,27 @@
+# Directories
+/.git
+/.github
+/.wordpress-org
+/bin
+/node_modules
+/tests
+/src
+/.idea
+/.php_cs
+/.php_cs.cache
+/.phpunit.result.cache
+/build
+/coverage
+/docs
+/vendor-bin
+# DO NOT EXCLUDE /vendor
+
+# Files
+.editorconfig
+.gitattributes
+.php_cs.dist
+composer.lock
+phpunit.xml.dist
+psalm.xml
+phpunit.xml
+psalm.xml

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: development, debugging, debug, developer
 Requires PHP: 8.0
 Requires at least: 5.5
 Tested up to: 6.1
-Stable tag: 1.7.0
+Stable tag: 1.7.2
 License: MIT
 
 Easily debug WordPress sites using Ray.

--- a/wp-ray.php
+++ b/wp-ray.php
@@ -4,7 +4,7 @@
  * Plugin Name: Spatie Ray
  * Plugin URI: https://github.com/spatie/wordpress-ray
  * Description: Easily debug WordPress apps
- * Version: 1.7.0
+ * Version: 1.7.2
  * Author: Spatie
  * Author URI: https://spatie.be
  * License: MIT


### PR DESCRIPTION
Sorry about that @freekmurze, vendor file seems to be still excluded from the deployment to Wordpress svn.

I have now added a `distignore` file. This seems to be used in [this repo](https://github.com/10up/autoshare-for-twitter) too (with same GitHub action for deployment).

Version is now 1.7.2.

Hopefully it works now! 🤞