### PR TITLE
Add .gitignore to .distignore and bump version

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -18,6 +18,7 @@
 # Files
 .editorconfig
 .gitattributes
+.gitignore
 .php_cs.dist
 composer.lock
 phpunit.xml.dist

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: development, debugging, debug, developer
 Requires PHP: 8.0
 Requires at least: 5.5
 Tested up to: 6.1
-Stable tag: 1.7.3
+Stable tag: 1.7.4
 License: MIT
 
 Easily debug WordPress sites using Ray.

--- a/wp-ray.php
+++ b/wp-ray.php
@@ -4,7 +4,7 @@
  * Plugin Name: Spatie Ray
  * Plugin URI: https://github.com/spatie/wordpress-ray
  * Description: Easily debug WordPress apps
- * Version: 1.7.2
+ * Version: 1.7.4
  * Author: Spatie
  * Author URI: https://spatie.be
  * License: MIT


### PR DESCRIPTION
As suggested by https://github.com/spatie/wordpress-ray/discussions/62.

This PR adds `.gitignore` to the list if ignored files for distribution.

PR also bumps the plugin to version 1.7.4.