### PR TITLE
Bump tested version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://github.com/sponsors/spatie
 Tags: development, debugging, debug, developer
 Requires PHP: 8.0
 Requires at least: 5.5
-Tested up to: 6.2
-Stable tag: 1.7.5
+Tested up to: 6.5
+Stable tag: 1.7.6
 License: MIT
 
 Easily debug WordPress sites using Ray.

--- a/wp-ray.php
+++ b/wp-ray.php
@@ -4,12 +4,12 @@
  * Plugin Name: Spatie Ray
  * Plugin URI: https://github.com/spatie/wordpress-ray
  * Description: Easily debug WordPress apps
- * Version: 1.7.5
+ * Version: 1.7.6
  * Author: Spatie
  * Author URI: https://spatie.be
  * License: MIT
  * Requires PHP: 8.0
- * Tested up to: 6.2
+ * Tested up to: 6.5
  */
 
 use Spatie\WordPressRay\Ray;


### PR DESCRIPTION
The plugin still seems to work just fine, and that hideous notice on dot org is undesirable, so let's bump the tested version.

It seems this project goes mostly unnoticed. I wouldn't mind keeping an eye on version compatibility if you could send a license my way. 😉

![2024-06-16-03-11-00](https://github.com/spatie/wordpress-ray/assets/2203813/c7b97426-5438-4999-92e5-bf63fc17f1ec)
